### PR TITLE
Provide pry's command prompt after eval

### DIFF
--- a/lib/better_errors/pry/repl/pry.rb
+++ b/lib/better_errors/pry/repl/pry.rb
@@ -61,7 +61,9 @@ module BetterErrors
       end
 
       def prompt
-        if indent = @pry.instance_variable_get(:@indent) and !indent.indent_level.empty?
+        if @pry.respond_to? :select_prompt
+          [@pry.select_prompt, ""]
+        elsif indent = @pry.instance_variable_get(:@indent) and !indent.indent_level.empty?
           ["..", indent.indent_level]
         else
           [">>", ""]

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe BetterErrors::ErrorPage do
         expect(do_eval).to include(
           highlighted_input: /stuff_was_done/,
           prefilled_input: '',
-          prompt: '>>',
+          prompt: '[2] pry(#<RSpec::ExampleGroups::BetterErrorsErrorPage::DoEval::WithPryEnabled>):1> ',
           result: "=> \"response\"\n",
         )
       end


### PR DESCRIPTION
Instead of always displaying ">>" as the prompt, ask Pry for the current prompt based on its context.

This doesn't change the fact that the initial console prompt is still ">>". That is a much more complicated enhancement, #2.

<img alt="better errors pry console with detailed prompt" src="https://user-images.githubusercontent.com/1005280/28998843-cbe4c542-7a02-11e7-92ee-15d5d3d1357a.png"/>
